### PR TITLE
PA-27: add factory for player, and extract game engine to own class

### DIFF
--- a/core/src/com/mygdx/game/ecs/GameEngine.java
+++ b/core/src/com/mygdx/game/ecs/GameEngine.java
@@ -1,0 +1,32 @@
+package com.mygdx.game.ecs;
+
+import com.badlogic.ashley.core.Entity;
+import com.badlogic.ashley.core.PooledEngine;
+import com.mygdx.game.ecs.entities.EntityFactory;
+import com.mygdx.game.ecs.systems.RenderSystem;
+
+public class GameEngine extends PooledEngine {
+    // GameEngine is a Singleton class
+    private static GameEngine gameEngineInstance = null;
+
+    private final EntityFactory entityFactory;
+
+    private GameEngine() {
+        entityFactory = EntityFactory.getInstance();
+    }
+
+    public static GameEngine getInstance() {
+        if (gameEngineInstance == null)
+            gameEngineInstance = new GameEngine();
+
+        return gameEngineInstance;
+    }
+
+    public void initializeEngine() {
+        Entity player = entityFactory.createPlayer(200, 200);
+
+        gameEngineInstance.addEntity(player);
+
+        gameEngineInstance.addSystem(new RenderSystem());
+    }
+}

--- a/core/src/com/mygdx/game/ecs/entities/EntityFactory.java
+++ b/core/src/com/mygdx/game/ecs/entities/EntityFactory.java
@@ -1,0 +1,25 @@
+package com.mygdx.game.ecs.entities;
+
+import com.badlogic.ashley.core.Entity;
+
+public class EntityFactory {
+    // EntityFactory is a Singleton class
+    private static EntityFactory entityFactoryInstance = null;
+
+    PlayerFactory playerFactory;
+
+    private EntityFactory() {
+        playerFactory = PlayerFactory.getInstance();
+    }
+
+    public static EntityFactory getInstance() {
+        if (entityFactoryInstance == null)
+            entityFactoryInstance = new EntityFactory();
+
+        return entityFactoryInstance;
+    }
+
+    public Entity createPlayer(float x, float y) {
+        return playerFactory.createPlayer(x, y);
+    }
+}

--- a/core/src/com/mygdx/game/ecs/entities/PlayerFactory.java
+++ b/core/src/com/mygdx/game/ecs/entities/PlayerFactory.java
@@ -1,0 +1,40 @@
+package com.mygdx.game.ecs.entities;
+
+import com.badlogic.ashley.core.Entity;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.mygdx.game.ecs.GameEngine;
+import com.mygdx.game.ecs.components.PositionComponent;
+import com.mygdx.game.ecs.components.SpriteComponent;
+
+public class PlayerFactory {
+    // PlayerFactory is a Singleton class
+    private static PlayerFactory playerFactoryInstance = null;
+
+    private PlayerFactory() {}
+
+    public static PlayerFactory getInstance() {
+        if (playerFactoryInstance == null)
+            playerFactoryInstance = new PlayerFactory();
+
+        return playerFactoryInstance;
+    }
+
+    Entity createPlayer(float x, float y) {
+        Entity player = GameEngine.getInstance().createEntity();
+
+        PositionComponent position = GameEngine.getInstance().createComponent(PositionComponent.class);
+        SpriteComponent sprite = GameEngine.getInstance().createComponent(SpriteComponent.class);
+
+        Texture playerSprite = new Texture("sprites/player.png");
+        sprite.textureRegion = new TextureRegion(playerSprite);
+
+        position.position.x = x;
+        position.position.y = y;
+
+        player.add(position);
+        player.add(sprite);
+
+        return player;
+    }
+}

--- a/core/src/com/mygdx/game/screens/game/GameView.java
+++ b/core/src/com/mygdx/game/screens/game/GameView.java
@@ -9,6 +9,7 @@ import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.viewport.ScreenViewport;
+import com.mygdx.game.ecs.GameEngine;
 import com.mygdx.game.ecs.components.PositionComponent;
 import com.mygdx.game.ecs.components.SpriteComponent;
 import com.mygdx.game.ecs.systems.RenderSystem;
@@ -19,36 +20,11 @@ public class GameView implements Screen {
     private Stage stage;
     private NavigatorController navigatorController;
 
-    private PooledEngine engine;
-
     public GameView(NavigatorController navigatorController) {
         this.navigatorController = navigatorController;
         stage = new Stage(new ScreenViewport());
         Gdx.input.setInputProcessor(stage);
-        initializeEngine();
-    }
-
-    private void initializeEngine() {
-        this.engine = new PooledEngine();
-
-        // Todo: extract player creation to its own factory
-        Entity player = engine.createEntity();
-
-        PositionComponent position = engine.createComponent(PositionComponent.class);
-        SpriteComponent sprite = engine.createComponent(SpriteComponent.class);
-
-        Texture playerSprite = new Texture("sprites/player.png");
-        sprite.textureRegion = new TextureRegion(playerSprite);
-
-        position.position.x = 200;
-        position.position.y = 200;
-
-        player.add(position);
-        player.add(sprite);
-
-        engine.addEntity(player);
-
-        engine.addSystem(new RenderSystem());
+        GameEngine.getInstance().initializeEngine();
     }
 
     @Override
@@ -63,7 +39,7 @@ public class GameView implements Screen {
 
         stage.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
         stage.draw();
-        engine.update(delta);
+        GameEngine.getInstance().update(delta);
     }
 
     @Override


### PR DESCRIPTION
#27 

Extracted GameEngine to its own class, so its easier to work with. 

Extracted the creation of a player entity to its own factory-class, and also made an intermediary EntityFactory-class, so the GameEngine doesn't have to keep track over all the different factories, but just the one. 

GameEngine, PlayerFactory and EntityFactory are all Singleton classes.