### PR TITLE
PA-19: implement basic player control system

### DIFF
--- a/core/src/com/mygdx/game/ecs/GameEngine.java
+++ b/core/src/com/mygdx/game/ecs/GameEngine.java
@@ -3,6 +3,7 @@ package com.mygdx.game.ecs;
 import com.badlogic.ashley.core.Entity;
 import com.badlogic.ashley.core.PooledEngine;
 import com.mygdx.game.ecs.entities.EntityFactory;
+import com.mygdx.game.ecs.systems.PlayerControlSystem;
 import com.mygdx.game.ecs.systems.RenderSystem;
 
 public class GameEngine extends PooledEngine {
@@ -28,5 +29,6 @@ public class GameEngine extends PooledEngine {
         gameEngineInstance.addEntity(player);
 
         gameEngineInstance.addSystem(new RenderSystem());
+        gameEngineInstance.addSystem(new PlayerControlSystem());
     }
 }

--- a/core/src/com/mygdx/game/ecs/components/PlayerComponent.java
+++ b/core/src/com/mygdx/game/ecs/components/PlayerComponent.java
@@ -4,8 +4,4 @@ import com.badlogic.ashley.core.Component;
 
 public class PlayerComponent implements Component {
     public int playerID;
-
-    public PlayerComponent (int playerID) {
-        this.playerID = playerID;
-    }
 }

--- a/core/src/com/mygdx/game/ecs/entities/PlayerFactory.java
+++ b/core/src/com/mygdx/game/ecs/entities/PlayerFactory.java
@@ -4,8 +4,10 @@ import com.badlogic.ashley.core.Entity;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.mygdx.game.ecs.GameEngine;
+import com.mygdx.game.ecs.components.PlayerComponent;
 import com.mygdx.game.ecs.components.PositionComponent;
 import com.mygdx.game.ecs.components.SpriteComponent;
+import com.mygdx.game.ecs.components.VelocityComponent;
 
 public class PlayerFactory {
     // PlayerFactory is a Singleton class
@@ -24,7 +26,9 @@ public class PlayerFactory {
         Entity player = GameEngine.getInstance().createEntity();
 
         PositionComponent position = GameEngine.getInstance().createComponent(PositionComponent.class);
+        VelocityComponent velocity = GameEngine.getInstance().createComponent(VelocityComponent.class);
         SpriteComponent sprite = GameEngine.getInstance().createComponent(SpriteComponent.class);
+        PlayerComponent playerComponent = GameEngine.getInstance().createComponent(PlayerComponent.class);
 
         Texture playerSprite = new Texture("sprites/player.png");
         sprite.textureRegion = new TextureRegion(playerSprite);
@@ -33,7 +37,9 @@ public class PlayerFactory {
         position.position.y = y;
 
         player.add(position);
+        player.add(velocity);
         player.add(sprite);
+        player.add(playerComponent);
 
         return player;
     }

--- a/core/src/com/mygdx/game/ecs/systems/PlayerControlSystem.java
+++ b/core/src/com/mygdx/game/ecs/systems/PlayerControlSystem.java
@@ -1,0 +1,32 @@
+package com.mygdx.game.ecs.systems;
+
+import com.badlogic.ashley.core.ComponentMapper;
+import com.badlogic.ashley.core.Entity;
+import com.badlogic.ashley.core.Family;
+import com.badlogic.ashley.systems.IteratingSystem;
+import com.mygdx.game.ecs.components.PlayerComponent;
+import com.mygdx.game.ecs.components.VelocityComponent;
+
+public class PlayerControlSystem extends IteratingSystem {
+    // Static variables updated from the touchpad changeListener
+    private static float moveJoystickX;
+    private static float moveJoystickY;
+
+    private ComponentMapper<VelocityComponent> velocityMapper;
+
+    public PlayerControlSystem() {
+        super(Family.all(PlayerComponent.class, VelocityComponent.class).get());
+
+        velocityMapper = ComponentMapper.getFor(VelocityComponent.class);
+    }
+
+    @Override
+    protected void processEntity(Entity entity, float deltaTime) {
+        velocityMapper.get(entity).velocity.set(moveJoystickX, moveJoystickY);
+    }
+
+    public static void setMoveJoystick(float x, float y) {
+        PlayerControlSystem.moveJoystickX = x;
+        PlayerControlSystem.moveJoystickY = y;
+    }
+}

--- a/core/src/com/mygdx/game/screens/game/GameView.java
+++ b/core/src/com/mygdx/game/screens/game/GameView.java
@@ -3,11 +3,14 @@ package com.mygdx.game.screens.game;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.Touchpad;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.utils.viewport.ScreenViewport;
 import com.mygdx.game.ecs.GameEngine;
+import com.mygdx.game.ecs.systems.PlayerControlSystem;
 import com.mygdx.game.screens.navigation.NavigatorController;
 
 public class GameView implements Screen {
@@ -35,6 +38,14 @@ public class GameView implements Screen {
         Touchpad move = new Touchpad(deadzoneRadius, skin);
         move.setSize(width * sizeFactor, width * sizeFactor);
         move.setPosition(width * widthFactor, height * heightFactor);
+        move.addListener(new ChangeListener() {
+            @Override
+            public void changed(ChangeEvent event, Actor actor) {
+                float deltaX = ((Touchpad) actor).getKnobPercentX();
+                float deltaY = ((Touchpad) actor).getKnobPercentY();
+                PlayerControlSystem.setMoveJoystick(deltaX, deltaY);
+            }
+        });
 
         Touchpad shoot = new Touchpad(deadzoneRadius, skin);
         shoot.setSize(width * sizeFactor, width * sizeFactor);


### PR DESCRIPTION
Implements a basic PlayerControlSystem. When the left joystick is moved, the velocity-component of the player is set accordingly. This means that the velocity of the player now is always between -1 and 1 (in any direction). 

When the ChangeListener in the touchpad gets triggered, it calls the static method of the PlayerControlSystem to set it's variables. This way, when using the PlayerControlSystem it can set the players velocity according to its own internal variables. 

Not sure if this is the best way to do it, I couldn't find a guide to cover our specific use-case of using touchpad, but it works as of now. 