### PR TITLE
PA-54: room show updated list of players in game

### DIFF
--- a/core/src/com/mygdx/game/firebase/FirebaseController.java
+++ b/core/src/com/mygdx/game/firebase/FirebaseController.java
@@ -1,5 +1,6 @@
 package com.mygdx.game.firebase;
 
+import com.mygdx.game.game_state.GameStateController;
 import com.mygdx.game.items.SimpleGameModel;
 import com.mygdx.game.screens.game_setup.GameSetupController;
 
@@ -9,9 +10,11 @@ public class FirebaseController implements FirebaseInterface {
     private static FirebaseController firebaseControllerInstance = null;
     private FirebaseInterface firebaseInterface;
     private GameSetupController gameSetupController;
+    private GameStateController gameStateController;
 
     private FirebaseController() {
         gameSetupController = GameSetupController.getInstance();
+        gameStateController = GameStateController.GameStateController();
     }
 
     public static FirebaseController getInstance() {
@@ -40,8 +43,27 @@ public class FirebaseController implements FirebaseInterface {
         firebaseInterface.listenToAvailableGames();
     }
 
+    @Override
+    public void stopListenToAvailableGames() {
+        firebaseInterface.stopListenToAvailableGames();
+    }
+
+    @Override
+    public void listenToPlayersInGame(String gameId) {
+        firebaseInterface.listenToPlayersInGame(gameId);
+    }
+
+    @Override
+    public void stopListenToPlayersInGame() {
+
+    }
+
 
     public void setAvailableGames(ArrayList<SimpleGameModel> availableGames) {
         gameSetupController.addAvailableGame(availableGames);
+    }
+
+    public void addPlayer(String player) {
+        gameStateController.addPlayer(player);
     }
 }

--- a/core/src/com/mygdx/game/firebase/FirebaseInterface.java
+++ b/core/src/com/mygdx/game/firebase/FirebaseInterface.java
@@ -4,4 +4,7 @@ public interface FirebaseInterface {
     public void writeToDb(String target, Object value);
     public void appendToArrayInDb(String target, Object value);
     public void listenToAvailableGames();
+    public void stopListenToAvailableGames();
+    public void listenToPlayersInGame(String gameId);
+    public void stopListenToPlayersInGame();
 }

--- a/core/src/com/mygdx/game/screens/game_setup/GameSetupController.java
+++ b/core/src/com/mygdx/game/screens/game_setup/GameSetupController.java
@@ -57,6 +57,9 @@ public class GameSetupController {
         firebaseController.writeToDb("game." + gameId, gameModel);
         firebaseController.appendToArrayInDb("game."+gameId+".playerUpdateModels", hostPlayerUpdateModel);
         firebaseController.appendToArrayInDb("game."+gameId+".players", gameStateModel.getHost());
+
+        firebaseController.stopListenToAvailableGames();
+        firebaseController.listenToPlayersInGame(gameId);
     }
 
     public void listenToAvailableGames() {
@@ -73,6 +76,9 @@ public class GameSetupController {
 
         firebaseController.appendToArrayInDb("game."+simpleGameModel.gameId+".playerUpdateModels", playerUpdateModel);
         firebaseController.appendToArrayInDb("game."+simpleGameModel.gameId+".players", gameStateModel.getUsername());
+
+        firebaseController.stopListenToAvailableGames();
+        firebaseController.listenToPlayersInGame(simpleGameModel.gameId);
     }
 
 }

--- a/core/src/com/mygdx/game/screens/room/RoomView.java
+++ b/core/src/com/mygdx/game/screens/room/RoomView.java
@@ -14,10 +14,12 @@ import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.utils.viewport.ScreenViewport;
 import com.mygdx.game.game_state.GameStateController;
 import com.mygdx.game.game_state.GameStateModel;
+import com.mygdx.game.items.SimpleGameModel;
 import com.mygdx.game.screens.navigation.NavigationModel;
 import com.mygdx.game.screens.navigation.NavigatorController;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 
 public class RoomView implements Screen {
     private NavigatorController navigatorController;
@@ -27,6 +29,11 @@ public class RoomView implements Screen {
     private GameStateModel gameStateModel;
     private GameStateController gameStateController;
 
+
+    private Skin skin;
+    private Table playersTable;
+
+    private Iterator<String> iter;
     private Stage stage;
 
     public RoomView(NavigatorController navigatorController,
@@ -50,10 +57,10 @@ public class RoomView implements Screen {
         rootTable.setFillParent(true);
         stage.addActor(rootTable);
 
-        Skin skin = new Skin(Gdx.files.internal("skin/neon-ui.json"));
+        skin = new Skin(Gdx.files.internal("skin/neon-ui.json"));
         skin.getFont("font").getData().setScale(5f);
 
-        Table playersTable = new Table();
+        playersTable = new Table();
         ScrollPane scrollPane = new ScrollPane(playersTable, skin);
         rootTable.add(scrollPane).size(1000,500);
 
@@ -66,15 +73,6 @@ public class RoomView implements Screen {
         titleLabel.setFontScale(6f);
         playersTable.add(titleLabel);
         playersTable.row().padTop(50);
-        Label hostLabel = new Label(gameStateModel.getHost() + " (host)", skin);
-        playersTable.add(hostLabel);
-        playersTable.row();
-
-        for (String player: mockPlayers) {
-            Label playerLabel = new Label(player, skin);
-            playersTable.add(playerLabel);
-            playersTable.row();
-        }
 
         if (gameStateModel.getHost() != null && gameStateModel.getHost().equals(gameStateModel.getUsername())){
             TextButton startGameButton = new TextButton("START GAME", skin);
@@ -98,6 +96,20 @@ public class RoomView implements Screen {
     public void render(float delta) {
         Gdx.gl.glClearColor(0f, 0f, 0f, 1);
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+
+        iter = this.gameStateModel.getPlayers().iterator();
+
+        while(iter.hasNext()) {
+            String player = iter.next();
+            String playerText = player;
+            if (player.equals(gameStateModel.getHost())) {
+                playerText = playerText.concat(" (host)");
+            }
+            Label playerLabel = new Label(playerText, skin);
+            playersTable.add(playerLabel);
+            playersTable.row();
+            iter.remove();
+        }
 
         stage.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
         stage.draw();

--- a/core/src/com/mygdx/game/screens/set_name/SetNameView.java
+++ b/core/src/com/mygdx/game/screens/set_name/SetNameView.java
@@ -38,11 +38,13 @@ public class SetNameView implements Screen {
         Table rootTable = new Table();
         rootTable.setFillParent(true);
         stage.addActor(rootTable);
+
         Skin skin = new Skin(Gdx.files.internal("skin/neon-ui.json"));
         skin.getFont("font").getData().setScale(5f);
 
         final TextField usernameField = new TextField("Name", skin);
         usernameField.setMaxLength(12);
+
         TextButton submitButton = new TextButton("Submit", skin);
 
 

--- a/desktop/src/com/mygdx/game/desktop/FirebaseController.java
+++ b/desktop/src/com/mygdx/game/desktop/FirebaseController.java
@@ -18,4 +18,9 @@ public class FirebaseController implements FirebaseInterface {
     public void listenToAvailableGames() {
 
     }
+
+    @Override
+    public void stopListenToAvailableGames() {
+
+    }
 }


### PR DESCRIPTION
When player join a game, or host create a new game they both start listening to all the players in the room. When new players are joining, they get updated on the screen in realtime. 

If the player added is the same as the host, the playerLabel will get (host) behind the playername. 

Also when entering the room, we stop listening for available games to save bandwith and performance.

![image](https://user-images.githubusercontent.com/30324054/114214653-dbe61380-9964-11eb-8df5-f4cdd546bc91.png)

closes #54 