### PR TITLE
chore: make player entity reachable from game engine

### DIFF
--- a/core/src/com/mygdx/game/ecs/GameEngine.java
+++ b/core/src/com/mygdx/game/ecs/GameEngine.java
@@ -26,6 +26,8 @@ public class GameEngine extends PooledEngine {
 
     private final EntityFactory entityFactory;
 
+    private Entity player;
+
     private GameEngine() {
         entityFactory = EntityFactory.getInstance();
     }
@@ -40,7 +42,7 @@ public class GameEngine extends PooledEngine {
     public void initializeEngine() {
         createBackground();
         addBotSpawner();
-        Entity player = entityFactory.createPlayer(200, 200);
+        player = entityFactory.createPlayer(200, 200);
 
         gameEngineInstance.addEntity(player);
 
@@ -83,5 +85,9 @@ public class GameEngine extends PooledEngine {
         spawner.add(botSpawnComponent);
 
         gameEngineInstance.addEntity(spawner);
+    }
+
+    public Entity getPlayer() {
+        return player;
     }
 }


### PR DESCRIPTION
Simple fix to make the player entity available from everywhere by using
GameEngine.getInstance().getPlayer
as it's handy to have access to the player from whereever you are. 