### PR TITLE
PA-17: implement basic collision-system

### DIFF
--- a/core/src/com/mygdx/game/ecs/GameEngine.java
+++ b/core/src/com/mygdx/game/ecs/GameEngine.java
@@ -11,6 +11,8 @@ import com.mygdx.game.ecs.components.PositionComponent;
 import com.mygdx.game.ecs.components.SpriteComponent;
 import com.mygdx.game.ecs.entities.EntityFactory;
 import com.mygdx.game.ecs.systems.BotSpawnSystem;
+import com.mygdx.game.ecs.systems.BoundSystem;
+import com.mygdx.game.ecs.systems.CollisionSystem;
 import com.mygdx.game.ecs.systems.HealthRenderSystem;
 import com.mygdx.game.ecs.systems.MovementSystem;
 import com.mygdx.game.ecs.systems.PlayerControlSystem;
@@ -55,6 +57,8 @@ public class GameEngine extends PooledEngine {
         gameEngineInstance.addSystem(new BotControlSystem());
         gameEngineInstance.addSystem(new HealthRenderSystem());
         gameEngineInstance.addSystem(new BotSpawnSystem());
+        gameEngineInstance.addSystem(new BoundSystem());
+        gameEngineInstance.addSystem(new CollisionSystem());
     }
 
     private void createBackground() {

--- a/core/src/com/mygdx/game/ecs/components/SpriteComponent.java
+++ b/core/src/com/mygdx/game/ecs/components/SpriteComponent.java
@@ -2,9 +2,12 @@ package com.mygdx.game.ecs.components;
 
 import com.badlogic.ashley.core.Component;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.math.Polygon;
 
 public class SpriteComponent implements Component {
     public TextureRegion textureRegion = null;
+    public Polygon polygon = null;
+    public boolean offset = false;
     public float scaleX = 1;
     public float scaleY = 1;
 }

--- a/core/src/com/mygdx/game/ecs/entities/BotFactory.java
+++ b/core/src/com/mygdx/game/ecs/entities/BotFactory.java
@@ -3,8 +3,10 @@ package com.mygdx.game.ecs.entities;
 import com.badlogic.ashley.core.Entity;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.math.Polygon;
 import com.mygdx.game.ecs.GameEngine;
 import com.mygdx.game.ecs.components.BotComponent;
+import com.mygdx.game.ecs.components.CollisionComponent;
 import com.mygdx.game.ecs.components.DirectionComponent;
 import com.mygdx.game.ecs.components.PositionComponent;
 import com.mygdx.game.ecs.components.SpriteComponent;
@@ -31,12 +33,28 @@ public class BotFactory {
         DirectionComponent direction = GameEngine.getInstance().createComponent(DirectionComponent.class);
         BotComponent botComponent = GameEngine.getInstance().createComponent(BotComponent.class);
         VelocityComponent velocity = GameEngine.getInstance().createComponent(VelocityComponent.class);
+        CollisionComponent collision = GameEngine.getInstance().createComponent(CollisionComponent.class);
 
         Texture zombieSprite = new Texture("sprites/zombie.png");
         sprite.textureRegion = new TextureRegion(zombieSprite);
+        sprite.offset = false;
+        sprite.scaleX = 1f;
+        sprite.scaleY = 1f;
 
         position.position.x = x;
         position.position.y = y;
+
+        float left = 25;
+        float bot = 10;
+        float right = 200;
+        float top = 190;
+        sprite.polygon = new Polygon(new float[]{
+                left,bot,
+                left,top,
+                right,top,
+                right,bot});
+        sprite.polygon.setPosition(x,y);
+        sprite.polygon.setOrigin((left+right) * 0.5f, (bot+top) * 0.5f);
 
         velocity.speed = 150;
 
@@ -45,6 +63,7 @@ public class BotFactory {
         zombie.add(direction);
         zombie.add(velocity);
         zombie.add(botComponent);
+        zombie.add(collision);
 
         return zombie;
     }

--- a/core/src/com/mygdx/game/ecs/entities/BulletFactory.java
+++ b/core/src/com/mygdx/game/ecs/entities/BulletFactory.java
@@ -3,9 +3,11 @@ package com.mygdx.game.ecs.entities;
 import com.badlogic.ashley.core.Entity;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.math.Polygon;
 import com.badlogic.gdx.math.Vector2;
 import com.mygdx.game.ecs.GameEngine;
 import com.mygdx.game.ecs.components.BulletComponent;
+import com.mygdx.game.ecs.components.CollisionComponent;
 import com.mygdx.game.ecs.components.DirectionComponent;
 import com.mygdx.game.ecs.components.PositionComponent;
 import com.mygdx.game.ecs.components.SpriteComponent;
@@ -32,27 +34,42 @@ public class BulletFactory {
         DirectionComponent direction = GameEngine.getInstance().createComponent(DirectionComponent.class);
         VelocityComponent velocity = GameEngine.getInstance().createComponent(VelocityComponent.class);
         BulletComponent bulletComp = GameEngine.getInstance().createComponent(BulletComponent.class);
+        CollisionComponent collision = GameEngine.getInstance().createComponent(CollisionComponent.class);
 
         Texture bulletSprite = new Texture("sprites/bullet.png");
         sprite.textureRegion = new TextureRegion(bulletSprite);
+        sprite.offset = true;
         sprite.scaleX = 0.1f;
         sprite.scaleY = 0.1f;
 
-        position.position.x = x - 253;
-        position.position.y = y - 216;
+        position.position.x = x+140;
+        position.position.y = y+20;
 
         direction.direction.set(dirX, dirY);
+
+        float left = 10;
+        float bot = 20;
+        float right = 70;
+        float top = 50;
+        sprite.polygon = new Polygon(new float[]{
+                left,bot,
+                left,top,
+                right,top,
+                right,bot});
+        sprite.polygon.setPosition(position.position.x,position.position.y);
+        sprite.polygon.setOrigin((left+right) * 0.5f-60, (bot+top) * 0.5f+50);
 
         velocity.speed = 100;
         velocity.velocity.set(direction.direction);
 
-        bulletComp.lifetime = 50;
+        bulletComp.lifetime = 1;
 
         bullet.add(position);
         bullet.add(sprite);
         bullet.add(direction);
         bullet.add(velocity);
         bullet.add(bulletComp);
+        bullet.add(collision);
 
         return bullet;
     }

--- a/core/src/com/mygdx/game/ecs/entities/PlayerFactory.java
+++ b/core/src/com/mygdx/game/ecs/entities/PlayerFactory.java
@@ -2,8 +2,11 @@ package com.mygdx.game.ecs.entities;
 
 import com.badlogic.ashley.core.Entity;
 import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.Sprite;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.math.Polygon;
 import com.mygdx.game.ecs.GameEngine;
+import com.mygdx.game.ecs.components.CollisionComponent;
 import com.mygdx.game.ecs.components.DirectionComponent;
 import com.mygdx.game.ecs.components.HealthComponent;
 import com.mygdx.game.ecs.components.PlayerComponent;
@@ -35,12 +38,30 @@ public class PlayerFactory {
         DirectionComponent direction = GameEngine.getInstance().createComponent(DirectionComponent.class);
         HealthComponent health = GameEngine.getInstance().createComponent(HealthComponent.class);
         ShootingComponent shooting = GameEngine.getInstance().createComponent(ShootingComponent.class);
+        CollisionComponent collision = GameEngine.getInstance().createComponent(CollisionComponent.class);
 
         Texture playerSprite = new Texture("sprites/player.png");
         sprite.textureRegion = new TextureRegion(playerSprite);
+        sprite.offset = false;
+        sprite.scaleX = 1f;
+        sprite.scaleY = 1f;
 
         position.position.x = x;
         position.position.y = y;
+
+
+        float left = 25;
+        float bot = 25;
+        float right = 225;
+        float top = 175;
+        sprite.polygon = new Polygon(new float[]{
+                left,bot,
+                left,top,
+                right,top,
+                right,bot});
+        sprite.polygon.setPosition(x,y);
+        sprite.polygon.setOrigin((left+right) * 0.5f, (bot+top) * 0.5f);
+        sprite.polygon.setRotation(direction.direction.angleDeg());
 
         velocity.speed = 500;
 
@@ -54,6 +75,7 @@ public class PlayerFactory {
         player.add(direction);
         player.add(health);
         player.add(shooting);
+        player.add(collision);
 
         return player;
     }

--- a/core/src/com/mygdx/game/ecs/systems/BoundSystem.java
+++ b/core/src/com/mygdx/game/ecs/systems/BoundSystem.java
@@ -1,0 +1,66 @@
+package com.mygdx.game.ecs.systems;
+
+import com.badlogic.ashley.core.ComponentMapper;
+import com.badlogic.ashley.core.Entity;
+import com.badlogic.ashley.core.Family;
+import com.badlogic.ashley.systems.IteratingSystem;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.utils.Array;
+import com.mygdx.game.ecs.components.BotComponent;
+import com.mygdx.game.ecs.components.BulletComponent;
+import com.mygdx.game.ecs.components.DirectionComponent;
+import com.mygdx.game.ecs.components.PlayerComponent;
+import com.mygdx.game.ecs.components.PositionComponent;
+import com.mygdx.game.ecs.components.SpriteComponent;
+
+public class BoundSystem extends IteratingSystem {
+    private final ComponentMapper<SpriteComponent> spriteMapper;
+    private final ComponentMapper<PositionComponent> positionMapper;
+    private final ComponentMapper<DirectionComponent> directionMapper;
+
+    private ShapeRenderer shapeRenderer;
+    private Array<Entity> renderQueue;
+
+    public BoundSystem() {
+        super(Family.all(SpriteComponent.class, PositionComponent.class, DirectionComponent.class).get());
+
+        spriteMapper = ComponentMapper.getFor(SpriteComponent.class);
+        positionMapper = ComponentMapper.getFor(PositionComponent.class);
+        directionMapper = ComponentMapper.getFor(DirectionComponent.class);
+
+        shapeRenderer = new ShapeRenderer();
+        renderQueue = new Array<Entity>();
+
+    }
+
+    /* update function only for debug purposes */
+    @Override
+    public void update(float deltaTime) {
+        super.update(deltaTime);
+
+        shapeRenderer.begin(ShapeRenderer.ShapeType.Line);
+
+        for (Entity entity: renderQueue) {
+            SpriteComponent sprite = spriteMapper.get(entity);
+            if (sprite.polygon == null) {
+                continue;
+            }
+            shapeRenderer.polygon(sprite.polygon.getTransformedVertices());
+        }
+        shapeRenderer.end();
+        renderQueue.clear();
+    }
+
+    @Override
+    protected void processEntity(Entity entity, float deltaTime) {
+        PositionComponent position = positionMapper.get(entity);
+        DirectionComponent direction = directionMapper.get(entity);
+        SpriteComponent sprite = spriteMapper.get(entity);
+        if (sprite.polygon != null) {
+            sprite.polygon.setPosition(position.position.x,position.position.y);
+            sprite.polygon.setRotation(direction.direction.angleDeg());
+        }
+        /* Uncomment the following line to display "hitboxes" */
+        //renderQueue.add(entity);
+    }
+}

--- a/core/src/com/mygdx/game/ecs/systems/BulletSystem.java
+++ b/core/src/com/mygdx/game/ecs/systems/BulletSystem.java
@@ -24,8 +24,7 @@ public class BulletSystem extends IteratingSystem {
         BulletComponent bullet = bulletMapper.get(entity);
 
         if (bullet.lifetime <= 0) {
-            GameEngine gameEngineInstance = GameEngine.getInstance();
-            gameEngineInstance.removeEntity(entity);
+            GameEngine.getInstance().removeEntity(entity);
         }
         else {
             bullet.lifetime -= deltaTime;

--- a/core/src/com/mygdx/game/ecs/systems/CollisionSystem.java
+++ b/core/src/com/mygdx/game/ecs/systems/CollisionSystem.java
@@ -1,0 +1,44 @@
+package com.mygdx.game.ecs.systems;
+
+import com.badlogic.ashley.core.ComponentMapper;
+import com.badlogic.ashley.core.Entity;
+import com.badlogic.ashley.core.Family;
+import com.badlogic.ashley.systems.IteratingSystem;
+import com.badlogic.ashley.utils.ImmutableArray;
+import com.badlogic.gdx.math.Intersector;
+import com.badlogic.gdx.math.Polygon;
+import com.mygdx.game.ecs.GameEngine;
+import com.mygdx.game.ecs.components.BotComponent;
+import com.mygdx.game.ecs.components.BulletComponent;
+import com.mygdx.game.ecs.components.CollisionComponent;
+import com.mygdx.game.ecs.components.PositionComponent;
+import com.mygdx.game.ecs.components.SpriteComponent;
+import com.mygdx.game.ecs.components.VelocityComponent;
+
+public class CollisionSystem extends IteratingSystem {
+    private ComponentMapper<SpriteComponent> spriteMapper;
+    private ComponentMapper<CollisionComponent> collisionMapper;
+
+    public CollisionSystem() {
+        super(Family.all(BotComponent.class, SpriteComponent.class, PositionComponent.class).get());
+        spriteMapper = ComponentMapper.getFor(SpriteComponent.class);
+    }
+
+    public void processEntity(Entity entity, float deltaTime) {
+        ImmutableArray<Entity> bullets = GameEngine.getInstance().getEntitiesFor(Family.all(BulletComponent.class).get());
+        for (Entity bullet : bullets) {
+            if(colliding(bullet, entity)) {
+                GameEngine.getInstance().removeEntity(entity);
+                GameEngine.getInstance().removeEntity(bullet);
+            }
+        }
+    }
+
+    public boolean colliding(Entity first, Entity second) {
+        Polygon firstPolygon = spriteMapper.get(first).polygon;
+        Polygon secondPolygon = spriteMapper.get(second).polygon;
+        boolean collision = Intersector.overlapConvexPolygons(firstPolygon, secondPolygon);
+        return collision;
+    }
+}
+

--- a/core/src/com/mygdx/game/ecs/systems/PlayerDirectionSystem.java
+++ b/core/src/com/mygdx/game/ecs/systems/PlayerDirectionSystem.java
@@ -26,7 +26,8 @@ public class PlayerDirectionSystem extends IteratingSystem {
     protected void processEntity(Entity entity, float deltaTime) {
         if (directionX == 0 && directionY == 0)
             return;
-        directionMapper.get(entity).direction.set(directionX, directionY);
+        DirectionComponent direction = directionMapper.get(entity);
+        direction.direction.set(directionX, directionY);
         ShootingSystem.setFire(isTouched);
     }
 

--- a/core/src/com/mygdx/game/ecs/systems/RenderSystem.java
+++ b/core/src/com/mygdx/game/ecs/systems/RenderSystem.java
@@ -46,10 +46,14 @@ public class RenderSystem extends IteratingSystem {
             PositionComponent positionComponent = positionMapper.get(entity);
             DirectionComponent directionComponent = directionMapper.get(entity);
 
-            float width = spriteComponent.textureRegion.getRegionWidth();
-            float height = spriteComponent.textureRegion.getRegionHeight();
+            float width = spriteComponent.textureRegion.getRegionWidth() * spriteComponent.scaleX;
+            float height = spriteComponent.textureRegion.getRegionHeight() * spriteComponent.scaleY;
             float originX = width * 0.5f;
             float originY = height * 0.5f;
+            if (spriteComponent.offset) {
+                originX -= 60;
+                originY += 50;
+            }
 
             spriteBatch.draw(
                     spriteComponent.textureRegion,
@@ -59,8 +63,8 @@ public class RenderSystem extends IteratingSystem {
                     originY,
                     width,
                     height,
-                    spriteComponent.scaleX,
-                    spriteComponent.scaleY,
+                    1,
+                    1,
                     directionComponent.direction.angleDeg());
         }
 


### PR DESCRIPTION
closes #17 

Det er fortsatt litt trøbbel med collisions. For det første blir ikke hitboxer plassert dynamisk nok. Det vil si at om vi skaper eksempelvis zombier av forskjellige størrelser vil deres synlige posisjon ikke matche med polygonet som er knyttet til dem.
For det andre, om flere zombier blir truffet av den samme kulen i samme frame vil alle de truffede bli borte, selv om kulen egentlig bare burde treffe én. Det kommer mest sannsynlig av måten jeg henter kule-entitetene fra. Det hender noen ganger at kuler går igjennom zombiene, så vi burde tenke på å redusere kulehastigheten noe.

https://user-images.githubusercontent.com/43404631/114762543-2b13b600-9d62-11eb-96df-3da66cb0fce1.mp4

Jeg vet ikke om det er en bug, men noen av zombiene ser ut til å bli skalert ned. Det var slik jeg merket den første bug-en.

Om man vil se polygonene knyttet til entitetene kan man gå i BoundSystem sin processEntity og avkommentere renderQueue.add(entity)
