### PR TITLE
PA-64: show player scores above healthbar

### DIFF
--- a/core/src/com/mygdx/game/ecs/GameEngine.java
+++ b/core/src/com/mygdx/game/ecs/GameEngine.java
@@ -13,7 +13,7 @@ import com.mygdx.game.ecs.entities.EntityFactory;
 import com.mygdx.game.ecs.systems.BotSpawnSystem;
 import com.mygdx.game.ecs.systems.BoundSystem;
 import com.mygdx.game.ecs.systems.CollisionSystem;
-import com.mygdx.game.ecs.systems.HealthRenderSystem;
+import com.mygdx.game.ecs.systems.PlayerHealthScoreSystem;
 import com.mygdx.game.ecs.systems.MovementSystem;
 import com.mygdx.game.ecs.systems.PlayerControlSystem;
 import com.mygdx.game.ecs.systems.PlayerDirectionSystem;
@@ -63,7 +63,7 @@ public class GameEngine extends PooledEngine {
         gameEngineInstance.addSystem(new ShootingSystem());
         gameEngineInstance.addSystem(new BulletSystem());
         gameEngineInstance.addSystem(new BotControlSystem());
-        gameEngineInstance.addSystem(new HealthRenderSystem());
+        gameEngineInstance.addSystem(new PlayerHealthScoreSystem());
         gameEngineInstance.addSystem(new BotSpawnSystem());
         gameEngineInstance.addSystem(new BoundSystem());
         gameEngineInstance.addSystem(new CollisionSystem());

--- a/core/src/com/mygdx/game/ecs/components/ExternalPlayerComponent.java
+++ b/core/src/com/mygdx/game/ecs/components/ExternalPlayerComponent.java
@@ -4,6 +4,6 @@ import com.badlogic.ashley.core.Component;
 
 public class ExternalPlayerComponent implements Component {
     public String playerName;
-    public boolean internal;
     public int index;
+    public int score;
 }

--- a/core/src/com/mygdx/game/ecs/systems/PlayerHealthScoreSystem.java
+++ b/core/src/com/mygdx/game/ecs/systems/PlayerHealthScoreSystem.java
@@ -12,10 +12,9 @@ import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.mygdx.game.ecs.components.BotComponent;
 import com.mygdx.game.ecs.components.ExternalPlayerComponent;
 import com.mygdx.game.ecs.components.HealthComponent;
-import com.mygdx.game.ecs.components.PlayerComponent;
 import com.mygdx.game.game_state.GlobalStateModel;
 
-public class HealthRenderSystem extends IteratingSystem {
+public class PlayerHealthScoreSystem extends IteratingSystem {
     private final ComponentMapper<HealthComponent> healthMapper;
     private final ComponentMapper<ExternalPlayerComponent> externalPlayerMapper;
 
@@ -35,7 +34,7 @@ public class HealthRenderSystem extends IteratingSystem {
     private GlobalStateModel globalStateModel;
     private int numberOfExternalPlayers;
 
-    public HealthRenderSystem() {
+    public PlayerHealthScoreSystem() {
         super(Family.all(HealthComponent.class).one(ExternalPlayerComponent.class).exclude(BotComponent.class).get());
 
         healthMapper = ComponentMapper.getFor(HealthComponent.class);
@@ -61,11 +60,12 @@ public class HealthRenderSystem extends IteratingSystem {
 
             // Updating healthComponent to use latest value from globalStateModel
             healthComponent.health = globalStateModel.getPlayerUpdateModels().get(externalPlayerComponent.playerName).health;
-            drawHealthBar(healthComponent, healthbarWidth, healthbarOriginX, originY, externalPlayerComponent.playerName);
+            externalPlayerComponent.score = globalStateModel.getPlayerUpdateModels().get(externalPlayerComponent.playerName).score;
+            drawNameHealthScore(healthComponent, healthbarWidth, healthbarOriginX, originY, externalPlayerComponent.playerName, externalPlayerComponent.score);
         }
     }
 
-    public void drawHealthBar(HealthComponent healthComponent, float maxHealthWidthAdjusted, float currOriginX, float currOriginY, String playerName) {
+    public void drawNameHealthScore(HealthComponent healthComponent, float maxHealthWidthAdjusted, float currOriginX, float currOriginY, String playerName, int playerScore) {
         // Calculate healthWidth to be shown, and maxHealthwidth
         float healthWidth = maxHealthWidthAdjusted * (healthComponent.health / healthComponent.maxHealth) - 2 * marginX;
         float maxHealthWidth = maxHealthWidthAdjusted - 2 * marginX;
@@ -92,11 +92,14 @@ public class HealthRenderSystem extends IteratingSystem {
         lineRenderer.rect(currOriginX, currOriginY, maxHealthWidth, healthBarHeight);
         lineRenderer.end();
 
-        // Write playername above healthbar
+        // Write playername and score above Health
         sb.begin();
-        font.getData().setScale(2);
+        font.getData().setScale(2.5f);
         font.setColor(Color.WHITE);
         font.draw(sb, playerName, currOriginX, currOriginY + 3 * healthBarHeight);
+
+        String score = String.valueOf(playerScore);
+        font.draw(sb, score , currOriginX + healthWidth - (25f * score.length()),currOriginY + 3 * healthBarHeight);
         sb.end();
     }
 }


### PR DESCRIPTION
Showing player score above healthbar. This is updated in realtime when DB changes. 

Renamed HealthRenderSystem to PlayerHealthScoreSystem, since this draws both healthbar, name and score.

![image](https://user-images.githubusercontent.com/30324054/114840892-8d5ace00-9dd7-11eb-9771-82ba814339d1.png)
